### PR TITLE
Make sure colors and icons links in styleguide use appropriate routes.

### DIFF
--- a/app/views/layouts/styleguide.html.erb
+++ b/app/views/layouts/styleguide.html.erb
@@ -9,10 +9,10 @@
 <div class='navigation'>
   <ul>
     <li>
-      <%= link_to 'Colors', 'colors' %>
+      <%= link_to 'Colors', colors_path %>
     </li>
     <li>
-      <%= link_to 'Icons', 'icons' %>
+      <%= link_to 'Icons', icons_path %>
     </li>
   </ul>
 </div>

--- a/spec/features/styleguide_spec.rb
+++ b/spec/features/styleguide_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'Styleguide' do
+  scenario 'Colors and Icon links' do
+    visit '/styleguide'
+    expect(page).not_to have_css('h2', text: 'Colors')
+    expect(page).not_to have_css('h3', text: 'Icons')
+
+    click_link 'Colors'
+    expect(page).to have_css('h2', text: 'Colors')
+    expect(page).not_to have_css('h3', text: 'Icons')
+
+    visit '/styleguide'
+    click_link 'Icons'
+    expect(page).not_to have_css('h2', text: 'Colors')
+    expect(page).to have_css('h3', text: 'Icons')
+  end
+
+end


### PR DESCRIPTION
The route that was being used was relative (`http://example.com/colors` instead of `http://example.com/styleguide/colors`) which threw a routing error.
