### PR TITLE
Add links to headings on Colors page

### DIFF
--- a/app/views/sul_styles/style_guide/colors.html.erb
+++ b/app/views/sul_styles/style_guide/colors.html.erb
@@ -1,6 +1,7 @@
 <h2>Colors</h2>
 <% @colors.each do |color_group| %>
-  <h3><%= color_group.title %></h3>
+  <% color_title = color_group.title.split(" from ") %>
+  <h3><%= link_to color_title[0], color_title[1] %></h3>
   <div class='color-sample-container'>
     <% color_group.colors.each do |color| %>
       <div class='color-sample'>


### PR DESCRIPTION
Very minor, but I thought it would be useful for the references on the color page be clickable links:

![stanford_university_libraries_-_style_guide 2](https://cloud.githubusercontent.com/assets/101482/9695446/ba65ee00-5316-11e5-9998-d44460f11c5f.png)

I did this in a simple way so feel free to reject or do something different. With this commit, the page looks like this:

![stanford_university_libraries_-_style_guide](https://cloud.githubusercontent.com/assets/101482/9695467/ebf2ca6a-5316-11e5-963a-3c2bb5992789.png)
